### PR TITLE
Ioloop optimizations

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,7 @@ Release notes
 .. toctree::
    :maxdepth: 2
 
+   releases/v5.2.0
    releases/v5.1.0
    releases/v5.0.2
    releases/v5.0.1

--- a/docs/releases/v5.2.0.rst
+++ b/docs/releases/v5.2.0.rst
@@ -1,0 +1,15 @@
+What's new in Tornado 5.2
+=========================
+
+Unreleased
+----------
+
+IOLoop optimizations
+~~~~~~~~~~~~~~~~~~~~
+
+IOLoop optimizations to reduce latency. Reduced the amount of roundtrips
+through the IOLoop required to finish a request by performing some
+callbacks synchronously. In particular, future done callbacks are usually
+safe to perform synchronously since that's what most Future implementations
+do anyway. Improved the fairness of the IOLoop schedule regarding timeouts,
+to reduce the maximum request latency when under constant pressure.

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ MacOS users should run:
 
 kwargs = {}
 
-version = "5.1"
+version = "5.2"
 
 with open('README.rst') as f:
     kwargs['long_description'] = f.read()

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ MacOS users should run:
 
 kwargs = {}
 
-version = "5.2"
+version = "5.2j"
 
 with open('README.rst') as f:
     kwargs['long_description'] = f.read()

--- a/tornado/__init__.py
+++ b/tornado/__init__.py
@@ -24,5 +24,5 @@ from __future__ import absolute_import, division, print_function
 # is zero for an official release, positive for a development branch,
 # or negative for a release candidate or beta (after the base version
 # number has been incremented)
-version = "5.1"
-version_info = (5, 1, 0, 0)
+version = "5.2"
+version_info = (5, 2, 0, 0)

--- a/tornado/concurrent.py
+++ b/tornado/concurrent.py
@@ -342,6 +342,10 @@ class Future(object):
         if not self._done:
             raise Exception("DummyFuture does not support blocking for results")
 
+    def _call_callbacks(self, callbacks):
+        for cb in callbacks:
+            cb(self)
+
     def _set_done(self):
         self._done = True
         if self._callbacks:

--- a/tornado/concurrent.py
+++ b/tornado/concurrent.py
@@ -345,11 +345,22 @@ class Future(object):
     def _set_done(self):
         self._done = True
         if self._callbacks:
-            from tornado.ioloop import IOLoop
-            loop = IOLoop.current()
-            for cb in self._callbacks:
-                loop.add_callback(cb, self)
+            callbacks = self._callbacks
             self._callbacks = None
+
+            # Invoke non-wrapped callbacks immediately
+            # Invoke wrapped ones in the IOLoop
+            wrapped_callbacks = []
+            for cb in callbacks:
+                if not hasattr(cb, '_wrapped'):
+                    cb(self)
+                else:
+                    wrapped_callbacks.append(cb)
+
+            if wrapped_callbacks:
+                from tornado.ioloop import IOLoop
+                IOLoop.current().add_callback(
+                    self._call_callbacks, wrapped_callbacks)
 
     # On Python 3.3 or older, objects with a destructor part of a reference
     # cycle are never destroyed. It's no longer the case on Python 3.4 thanks to

--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -411,7 +411,7 @@ class HTTP1Connection(httputil.HTTPConnection):
             if chunk:
                 data += self._format_chunk(chunk)
             self._pending_write = self.stream.write(data)
-            self._pending_write.add_done_callback(self._on_write_complete)
+            future_add_done_callback(self._pending_write, self._on_write_complete)
         return future
 
     def _format_chunk(self, chunk):
@@ -449,7 +449,7 @@ class HTTP1Connection(httputil.HTTPConnection):
             else:
                 future = self._write_future = Future()
             self._pending_write = self.stream.write(self._format_chunk(chunk))
-            self._pending_write.add_done_callback(self._on_write_complete)
+            future_add_done_callback(self._pending_write, self._on_write_complete)
         return future
 
     def finish(self):
@@ -464,7 +464,7 @@ class HTTP1Connection(httputil.HTTPConnection):
         if self._chunking_output:
             if not self.stream.closed():
                 self._pending_write = self.stream.write(b"0\r\n\r\n")
-                self._pending_write.add_done_callback(self._on_write_complete)
+                future_add_done_callback(self._pending_write, self._on_write_complete)
         self._write_finished = True
         # If the app finished the request while we're still reading,
         # divert any remaining data away from the delegate and

--- a/tornado/http1connection.py
+++ b/tornado/http1connection.py
@@ -155,8 +155,8 @@ class HTTP1Connection(httputil.HTTPConnection):
     def _read_message(self, delegate):
         need_delegate_close = False
         try:
-            header_future = self.stream.read_until_regex(
-                b"\r?\n\r?\n",
+            header_future = self.stream.read_until(
+                b"\r\n\r\n",
                 max_bytes=self.params.max_header_size)
             if self.params.header_timeout is None:
                 header_data = yield header_future

--- a/tornado/httputil.py
+++ b/tornado/httputil.py
@@ -212,7 +212,7 @@ class HTTPHeaders(collections.MutableMapping):
 
         """
         h = cls()
-        for line in _CRLF_RE.split(headers):
+        for line in headers.splitlines():
             if line:
                 h.parse_line(line)
         return h

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -1027,14 +1027,14 @@ class PollIOLoop(IOLoop):
                     callback = due_timeouts[i].callback
                     if callback is not None:
                         run_callback(callback)
-                for i in xrange(ndue_timeouts, ncallbacks):
-                    # Run residual callbacks
-                    run_callback(pop_callback())
                 for i in xrange(ncallbacks, ndue_timeouts):
                     # Run residual timeouts
                     callback = due_timeouts[i].callback
                     if callback is not None:
                         run_callback(callback)
+                for i in xrange(ndue_timeouts, ncallbacks):
+                    # Run residual callbacks
+                    run_callback(pop_callback())
                 del pop_callback, run_callback
 
                 # Closures may be holding on to a lot of memory, so allow

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -55,7 +55,7 @@ from tornado.platform.auto import set_close_exec, Waker
 from tornado import stack_context
 from tornado.util import (
     PY3, Configurable, errno_from_exception, timedelta_to_seconds,
-    TimeoutError, unicode_type, import_object,
+    TimeoutError, unicode_type, import_object, xrange,
 )
 
 try:
@@ -993,17 +993,7 @@ class PollIOLoop(IOLoop):
                 due_timeouts = []
                 if self._timeouts:
                     now = self.time()
-                    while self._timeouts:
-                        if self._timeouts[0].callback is None:
-                            # The timeout was cancelled.  Note that the
-                            # cancellation check is repeated below for timeouts
-                            # that are cancelled by another timeout or callback.
-                            heapq.heappop(self._timeouts)
-                            self._cancellations -= 1
-                        elif self._timeouts[0].deadline <= now:
-                            due_timeouts.append(heapq.heappop(self._timeouts))
-                        else:
-                            break
+
                     if (self._cancellations > 512 and
                             self._cancellations > (len(self._timeouts) >> 1)):
                         # Clean up the timeout queue when it gets large and it's
@@ -1013,14 +1003,43 @@ class PollIOLoop(IOLoop):
                                           if x.callback is not None]
                         heapq.heapify(self._timeouts)
 
-                for i in range(ncallbacks):
-                    self._run_callback(self._callbacks.popleft())
-                for timeout in due_timeouts:
-                    if timeout.callback is not None:
-                        self._run_callback(timeout.callback)
+                    timeouts = self._timeouts
+                    heappop = heapq.heappop
+                    while timeouts:
+                        if timeouts[0].callback is None:
+                            # The timeout was cancelled.  Note that the
+                            # cancellation check is repeated below for timeouts
+                            # that are cancelled by another timeout or callback.
+                            heappop(timeouts)
+                            self._cancellations -= 1
+                        elif timeouts[0].deadline <= now:
+                            due_timeouts.append(heappop(timeouts))
+                        else:
+                            break
+                    del timeouts, heappop
+
+                ndue_timeouts = len(due_timeouts)
+                pop_callback = self._callbacks.popleft
+                run_callback = self._run_callback
+                for i in xrange(min(ncallbacks, ndue_timeouts)):
+                    # Multiplex callbacks and timeouts
+                    run_callback(pop_callback())
+                    callback = due_timeouts[i].callback
+                    if callback is not None:
+                        run_callback(callback)
+                for i in xrange(ndue_timeouts, ncallbacks):
+                    # Run residual callbacks
+                    run_callback(pop_callback())
+                for i in xrange(ncallbacks, ndue_timeouts):
+                    # Run residual timeouts
+                    callback = due_timeouts[i].callback
+                    if callback is not None:
+                        run_callback(callback)
+                del pop_callback, run_callback
+
                 # Closures may be holding on to a lot of memory, so allow
                 # them to be freed before we go into our poll wait.
-                due_timeouts = timeout = None
+                due_timeouts = timeout = callback = None
 
                 if self._callbacks:
                     # If any callbacks or timeouts called add_callback,

--- a/tornado/locks.py
+++ b/tornado/locks.py
@@ -210,7 +210,11 @@ class Event(object):
         if not self._value:
             self._value = True
 
+            ndone = []
             for fut in self._waiters:
+                if not fut.done():
+                    ndone.append(fut)
+            for fut in ndone:
                 if not fut.done():
                     fut.set_result(None)
 

--- a/tornado/test/httpserver_test.py
+++ b/tornado/test/httpserver_test.py
@@ -243,13 +243,6 @@ class HTTPConnectionTest(AsyncHTTPTestCase):
         self.assertEqual(u"\u00f3", data["filename"])
         self.assertEqual(u"\u00fa", data["filebody"])
 
-    def test_newlines(self):
-        # We support both CRLF and bare LF as line separators.
-        for newline in (b"\r\n", b"\n"):
-            response = self.raw_fetch([b"GET /hello HTTP/1.0"], b"",
-                                      newline=newline)
-            self.assertEqual(response, b'Hello world')
-
     @gen_test
     def test_100_continue(self):
         # Run through a 100-continue interaction by hand:

--- a/tornado/test/httputil_test.py
+++ b/tornado/test/httputil_test.py
@@ -344,18 +344,6 @@ Foo: even
                                     newline, encoding)
                     raise
 
-    def test_optional_cr(self):
-        # Both CRLF and LF should be accepted as separators. CR should not be
-        # part of the data when followed by LF, but it is a normal char
-        # otherwise (or should bare CR be an error?)
-        headers = HTTPHeaders.parse(
-            'CRLF: crlf\r\nLF: lf\nCR: cr\rMore: more\r\n')
-        self.assertEqual(sorted(headers.get_all()),
-                         [('Cr', 'cr\rMore: more'),
-                          ('Crlf', 'crlf'),
-                          ('Lf', 'lf'),
-                          ])
-
     def test_copy(self):
         all_pairs = [('A', '1'), ('A', '2'), ('B', 'c')]
         h1 = HTTPHeaders()

--- a/tornado/util.py
+++ b/tornado/util.py
@@ -23,6 +23,8 @@ PY3 = sys.version_info >= (3,)
 
 if PY3:
     xrange = range
+else:
+    xrange = __builtins__['xrange']
 
 # inspect.getargspec() raises DeprecationWarnings in Python 3.5.
 # The two functions have compatible interfaces for the parts we need.


### PR DESCRIPTION
IOLoop optimizations to reduce latency. Reduced the amount of roundtrips
through the IOLoop required to finish a request by performing some
callbacks synchronously. In particular, future done callbacks are usually
safe to perform synchronously since that's what most Future implementations
do anyway. Improved the fairness of the IOLoop schedule regarding timeouts,
to reduce the maximum request latency when under constant pressure.

Also no longer accept LF as sole EOL char, require CRLF. For our use case,
that's more than OK, and the cost of applying regexes to input data looking for
CRLF or LF is quite high (1ms per 64k of input data).