### PR TITLE
Add patch version to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ MacOS users should run:
 
 kwargs = {}
 
-version = "5.2j"
+version = "5.2.0j"
 
 with open('README.rst') as f:
     kwargs['long_description'] = f.read()


### PR DESCRIPTION
Otherwise, the j suffix might be incorrectly interpreted when
we try to release a 5.2.1j