### PR TITLE
IOLoop optimizations

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,7 @@ Release notes
 .. toctree::
    :maxdepth: 2
 
+   releases/v5.2.1
    releases/v5.2.0
    releases/v5.1.0
    releases/v5.0.2

--- a/docs/releases/v5.2.1.rst
+++ b/docs/releases/v5.2.1.rst
@@ -1,5 +1,5 @@
-What's new in Tornado 5.2
-=========================
+What's new in Tornado 5.2.1
+===========================
 
 Unreleased
 ----------

--- a/docs/releases/v5.2.1.rst
+++ b/docs/releases/v5.2.1.rst
@@ -1,0 +1,11 @@
+What's new in Tornado 5.2
+=========================
+
+Unreleased
+----------
+
+IOLoop optimizations
+~~~~~~~~~~~~~~~~~~~~
+
+IOLoop optimizations to reduce GC pressure by breaking cycles earlier.
+

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ MacOS users should run:
 
 kwargs = {}
 
-version = "5.2.0j"
+version = "5.2.1j"
 
 with open('README.rst') as f:
     kwargs['long_description'] = f.read()

--- a/tornado/__init__.py
+++ b/tornado/__init__.py
@@ -25,4 +25,4 @@ from __future__ import absolute_import, division, print_function
 # or negative for a release candidate or beta (after the base version
 # number has been incremented)
 version = "5.2"
-version_info = (5, 2, 0, 0)
+version_info = (5, 2, 1, 0)

--- a/tornado/gen.pxd
+++ b/tornado/gen.pxd
@@ -1,3 +1,5 @@
+cdef object wrap
+
 cdef class Runner:
     cdef object __weakref__
     cdef dict __dict__
@@ -14,8 +16,14 @@ cdef class Runner:
     cdef public object io_loop
     cdef public object stack_context_deactivate
 
+    cpdef _deactivate_stack_context(self)
+    cpdef _start_yield_point(self, yielded, bint run)
+    cpdef int handle_yield(self, yielded) except? -1
+
 cpdef convert_yielded(yielded)
-cpdef _contains_yieldpoint(children)
+cpdef bint _contains_yieldpoint(children)
+cpdef _create_future()
+cpdef _value_from_stopiteration(e)
 
 from tornado.concurrent cimport (is_future, future_set_exc_info,
                                  future_add_done_callback, future_set_result_unless_cancelled)

--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -1164,7 +1164,7 @@ class PollIOLoop(IOLoop):
         heapq.heappush(self._timeouts, timeout)
         return timeout
 
-    @cython.locals(timeout = _Timeout)
+    @cython.locals(timeout = '_Timeout')
     def remove_timeout(self, timeout):
         # Removing from a heap is complicated, so just leave the defunct
         # timeout object in the queue (see discussion in
@@ -1181,7 +1181,10 @@ class PollIOLoop(IOLoop):
             return
         # Blindly insert into self._callbacks. This is safe even
         # from signal handlers because deque.append is atomic.
-        self._callbacks.append(partial(wrap(callback), *args, **kwargs))
+        callback = wrap(callback)
+        if args or kwargs:
+            callback = partial(callback, *args, **kwargs)
+        self._callbacks.append(callback)
         if get_ident() != self._thread_ident:
             # This will write one byte but Waker.consume() reads many
             # at once, so it's ok to write even when not strictly


### PR DESCRIPTION
Second batch of IOLoop optimizations:
- Avoid add_future in critical coroutine paths, since add_future
  tends to delay GC
- Refactor inner callback to not keep references to the yielded
  futures, and thus reduce GC pressure
- Cython optimization stuff, try to make more native calls
- Reuse the runner itself as future callback in the hack used to
  keep a strong reference to the runner tied to the callback, to
  avoid creating lambdas which take quite some doing